### PR TITLE
Improve mount resources recycling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ test:
 		./app/... \
 		./proxy/... \
 		./vessel/... \
-		./utils/... 
+		./utils/... \
+		./resources/... 
 
 binary:
 	go build -ldflags "$(GO_LDFLAGS)" -a -tags "netgo osusergo" -installsuffix netgo -o eru-barrel

--- a/barrel.go
+++ b/barrel.go
@@ -48,7 +48,7 @@ func run(c *cli.Context) (err error) {
 	hostEnvVars := c.StringSlice("host")
 	log.Printf("hostEnvVars = %v", hostEnvVars)
 
-	resources.Init(c.StringSlice("res-path"))
+	resources.Init(c.StringSlice("res-path-prefix"))
 
 	hostname := c.String("hostname")
 	if hostname == "" {
@@ -113,9 +113,9 @@ func main() {
 				EnvVars: []string{"BARREL_HOSTS"},
 			},
 			&cli.StringSliceFlag{
-				Name:    "res-path",
-				Usage:   "resource paths, can set multiple times",
-				EnvVars: []string{"BARREL_RESOURCE_PATHS"},
+				Name:    "res-path-prefix",
+				Usage:   "resource path prefix, can set multiple times",
+				EnvVars: []string{"BARREL_RESOURCE_PATH_PREFIXES"},
 			},
 			&cli.StringFlag{
 				Name:    "tls-cert",

--- a/proxy/docker/remove.go
+++ b/proxy/docker/remove.go
@@ -103,15 +103,13 @@ func (handler containerDeleteHandler) releaseResources(containerInfo containerIn
 }
 
 func (handler containerDeleteHandler) releaseMounts(containerInfo containerInspectResult) {
-	logger := handler.Logger("releaseMounts")
-
+	var paths []string
 	for _, mnt := range containerInfo.Mounts {
 		if mnt.Source != "" {
-			if err := resources.RecycleResources(logger, mnt.Source); err != nil {
-				logger.Errorf("remove mount error, source = %s", mnt.Source)
-			}
+			paths = append(paths, mnt.Source)
 		}
 	}
+	resources.RecycleMounts(paths)
 }
 
 func (handler containerDeleteHandler) releaseReservedIP(id string) {

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -1,0 +1,22 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonObject(t *testing.T) {
+	pathes := []string{
+		"/data/biz/cluster01/container01/data",
+		"/data/biz/cluster01/container01/log",
+		"/data/biz/cluster01/container01",
+		"/data/biz/cluster02/container01/data",
+		"/data/biz/cluster02/container01/log",
+		"/data/biz/cluster02/container01",
+	}
+	newPathes := minify(pathes)
+	assert.Equal(t, 2, len(newPathes))
+	assert.Equal(t, "/data/biz/cluster01/container01", newPathes[0])
+	assert.Equal(t, "/data/biz/cluster02/container01", newPathes[1])
+}


### PR DESCRIPTION
Will try minify mount resource paths before remove. 
For example:
```
"mounts": [
  "/data/container01/data",
  "/data/container01/log",
  "/data/container01",
],
```
Will only perform remove /data/container01 once.