### PR TITLE
Update GitHub action of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.31
+          version: v1.40
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,18 +25,23 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    # golint is replaced by revive
+    # - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
+    # interfacer is deprecated
+    # - interfacer
     - misspell
     - nakedret
     - nolintlint
     - rowserrcheck
-    - scopelint
+    # scopelint is replaced by exportloopref
+    # - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - typecheck


### PR DESCRIPTION
In this PR, the github action of golangci-lint version is updated to latest version. Also some deprecated lint plugins is removed or replaced by new ones.