### PR TITLE
Fix bugs when transfer chunked result

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -66,6 +66,11 @@ func (ph HTTPProxyHandler) proxy(response http.ResponseWriter, request *http.Req
 		return
 	}
 	if resp.StatusCode != http.StatusSwitchingProtocols {
+		if request.Method == http.MethodGet && utils.IsChunkedEncoding(resp) {
+			log.Debug("[dispatch] Forward chunked response")
+			utils.ForwardChunked(response, resp)
+			return
+		}
 		log.Debug("[dispatch] Forward http response")
 		if err := utils.Forward(resp, response); err != nil {
 			log.Errorf("[dispatch] forward docker socket response failed %v", err)


### PR DESCRIPTION
this PR fix bugs when transfering chunked result

when request is get and response is trunked, http response from dockerd will be write to proxy response and flush right away.

this only applys to get request and chunked response in order to fix /events api, do not invovle other circumstances in order not to involve too many test to catch up with 9.9