### PR TITLE
[Bugfix]Fix docker cli client not assigned to docker network manager

### DIFF
--- a/vessel/docker_network.go
+++ b/vessel/docker_network.go
@@ -28,6 +28,7 @@ func NewDockerNetworkManager(dockerCli *dockerClient.Client, driverName string, 
 		allocator:     allocator,
 		driverName:    driverName,
 		LoggerFactory: utils.NewObjectLogger("dockerNetworkManager"),
+		dockerCli:     dockerCli,
 	}
 }
 


### PR DESCRIPTION
In this PR, a bug is fixed that docker client is not assigned to network manager. The bug is introduced in my last PR to improve cli utils , and no environment is effected yet.